### PR TITLE
Fix drag-and-drop setup

### DIFF
--- a/GUI.py
+++ b/GUI.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import tkinter as tk
 from tkinter import filedialog, messagebox, ttk
 
@@ -7,11 +8,21 @@ try:
     from tkinterdnd2 import DND_FILES, TkinterDnD
     HAS_DND = True
 except ImportError:
-    HAS_DND = False
+    try:
+        subprocess.run([sys.executable, "-m", "pip", "install", "tkinterdnd2"], check=True)
+        from tkinterdnd2 import DND_FILES, TkinterDnD
+        HAS_DND = True
+    except Exception:
+        print("Drag-and-drop disabled. Install tkinterdnd2 for this feature.")
+        HAS_DND = False
 
 def install_dependencies():
     """Runs the installation script for RIFE and FFmpeg."""
-    subprocess.run(["python", "install_requirements.py"], check=True)
+    try:
+        subprocess.run([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"], check=True)
+        subprocess.run([sys.executable, "install_requirements.py"], check=True)
+    except subprocess.CalledProcessError:
+        print("Failed to run install_requirements.py. Ensure requirements.txt packages are installed.")
     # messagebox.showinfo("Installation", "Dependencies installed successfully!")
 
 def select_video():

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ VideoEnhancer provides scripts for video frame interpolation using RIFE and opti
 
 ## Installation
 
-Run the provided installer to fetch RIFE, FFmpeg and Python dependencies:
+Install the required Python packages and fetch the RIFE and FFmpeg binaries:
 
 ```bash
+pip install -r requirements.txt
 python install_requirements.py
 ```
 


### PR DESCRIPTION
## Summary
- install Python packages when launching the GUI
- fall back gracefully if tkinterdnd2 isn't available
- document installing requirements in README

## Testing
- `python -m py_compile GUI.py`
- `python -m py_compile interpolate_video.py upscale_video.py install_requirements.py detect_frame_rate.py remove_duplicates.py`


------
https://chatgpt.com/codex/tasks/task_e_68594b1c789c83339dee1a5e8d24ca10