### PR TITLE
Fix update script remote lookup

### DIFF
--- a/update_repo.py
+++ b/update_repo.py
@@ -3,20 +3,23 @@ import subprocess
 import sys
 
 
-def get_remote_url():
-    """Return the URL of the remote named 'origin', if it exists."""
+def get_remote_url(repo_dir: str) -> str | None:
+    """Return the URL of the remote named 'origin' for the given repo."""
     try:
-        return subprocess.check_output(
-            ["git", "config", "--get", "remote.origin.url"],
-            text=True,
-        ).strip()
+        return (
+            subprocess.check_output(
+                ["git", "-C", repo_dir, "config", "--get", "remote.origin.url"],
+                text=True,
+            )
+            .strip()
+        )
     except subprocess.CalledProcessError:
         return None
 
 
 def update_repo():
     repo_dir = os.path.dirname(os.path.abspath(__file__))
-    remote = get_remote_url()
+    remote = get_remote_url(repo_dir)
     if not remote:
         print("❌ No remote repository configured. Cannot update.")
         return


### PR DESCRIPTION
## Summary
- make sure `update_repo.py` searches for origin URL inside the repo directory

## Testing
- `python -m py_compile update_repo.py`

------
https://chatgpt.com/codex/tasks/task_e_6859504dee4c8333ac33039968ada748