### PR TITLE
Remove unused latent upscaler import

### DIFF
--- a/upscale_video.py
+++ b/upscale_video.py
@@ -12,7 +12,6 @@ from PIL import Image
 import torch
 from diffusers import (
     StableDiffusionUpscalePipeline,
-    StableDiffusionLatentUpscalePipeline,
     LDMSuperResolutionPipeline,
 )
 


### PR DESCRIPTION
## Summary
- clean up `upscale_video.py` by dropping `StableDiffusionLatentUpscalePipeline` import

## Testing
- `python -m py_compile upscale_video.py`


------
https://chatgpt.com/codex/tasks/task_e_68597b3eeb388333be318d8d1207f91c