### PR TITLE
Check for model binary in upscale_frames

### DIFF
--- a/upscale_video.py
+++ b/upscale_video.py
@@ -167,6 +167,11 @@ def upscale_frames(model: str, scale: int, input_folder: str, output_folder: str
         "swinir": SWINIR_EXECUTABLE,
     }
     exe = exe_map.get(model)
+    # Verify that the executable exists either on PATH or at the given path
+    if not shutil.which(exe) and not os.path.isfile(exe):
+        raise FileNotFoundError(
+            f"❌ Model binary '{exe}' was not found. Ensure it is installed and on your PATH."
+        )
     cmd = [exe, "-i", input_folder, "-o", output_folder, "-s", str(scale), "-f", "png"]
     if gpu is not None:
         cmd.extend(["-g", str(gpu)])


### PR DESCRIPTION
## Summary
- verify the presence of NCNN executables before running

## Testing
- `python -m py_compile upscale_video.py`
- `python upscale_video.py --help` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_68597b3d6a008333b3ccd1b36fb7cee3